### PR TITLE
Benchmark

### DIFF
--- a/.github/workflows/publish_artifact.yml
+++ b/.github/workflows/publish_artifact.yml
@@ -96,9 +96,6 @@ jobs:
       - name: ccache epilog
         run: |
           ccache -s # Print current cache stats
-      - name: Import GEMM library from a separate wasm module
-        working-directory: bergamot-translator/build-wasm-without-wormhole
-        run: bash ../wasm/patch-artifacts-import-gemm-module.sh
       - name: Upload wasm artifact
         uses: actions/upload-artifact@v2
         with:

--- a/extension/3rd_party/js-untar/untar.js
+++ b/extension/3rd_party/js-untar/untar.js
@@ -1,6 +1,6 @@
 /* globals Blob: false, Promise: false, console: false, Worker: false, ProgressivePromise: false */
 
-var workerScriptUri = '3rd_party/js-untar/untar-worker.js';
+var workerScriptUri = browser.runtime.getURL('3rd_party/js-untar/untar-worker.js');
 
 var global = window || this;
 

--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -72,6 +72,8 @@ on('Update', diff => {
     }
 });
 
+const sessionID = new Date().getTime();
+
 const inPageTranslation = new InPageTranslation({
     translate(text, user) {
         console.assert(state.from !== undefined && state.to !== undefined);
@@ -88,7 +90,13 @@ const inPageTranslation = new InPageTranslation({
                 user,
                 
                 // data useful for the scheduling
-                priority: user.priority || 0
+                priority: user.priority || 0,
+
+                // data useful for recording
+                session: {
+                    id: sessionID,
+                    url: document.location.href
+                }
             }
         });
     }

--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -233,7 +233,11 @@ const providers = {
 
 // Global state (and defaults)
 const state = {
-    provider: 'wasm'
+    provider: 'wasm',
+    options: {
+        workers: 1,
+        useNativeIntGemm: true
+    }
 };
 
 // State per tab
@@ -262,7 +266,7 @@ let provider = new class {
             state.provider = 'wasm';
         }
         
-        this.#provider = new providers[state.provider]();
+        this.#provider = new providers[state.provider](state.options);
 
         this.#provider.onerror = err => {
             console.error('Translation provider error:', err);

--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -305,7 +305,8 @@ const state = {
         workers: 1, // be kind to the user's pc
         cacheSize: 20000, // remember website boilerplate
         useNativeIntGemm: true // faster is better (unless it is buggy: https://github.com/browsermt/marian-dev/issues/81)
-    }
+    },
+    developer: false // should we show the option to record page translation requests?
 };
 
 // State per tab
@@ -460,8 +461,9 @@ function connectContentScript(contentScript) {
                 }));
 
                 // If we're recording requests from this tab, add the translation
-                // request.
-                if (tab.state.record) {
+                // request. Also disabled when developer setting is false since
+                // then there are no controls to turn it on/off.
+                if (state.developer && tab.state.record) {
                     recorder.record(message.data);
                     tab.update(state => ({
                         recordedPagesCount: recorder.size

--- a/extension/controller/backgroundScript.js
+++ b/extension/controller/backgroundScript.js
@@ -303,8 +303,9 @@ const providers = {
 const state = {
     provider: 'wasm',
     options: {
-        workers: 1,
-        useNativeIntGemm: true
+        workers: 1, // be kind to the user's pc
+        cacheSize: 20000, // remember website boilerplate
+        useNativeIntGemm: true // faster is better (unless it is buggy: https://github.com/browsermt/marian-dev/issues/81)
     }
 };
 

--- a/extension/controller/translation/TLTranslationHelper.js
+++ b/extension/controller/translation/TLTranslationHelper.js
@@ -23,18 +23,16 @@ class PortChannel {
         return new PromiseWithProgress((resolve, reject, update) => {
             const id = ++this.serial;
             this.pending.set(id, {resolve, reject, update});
-            console.log('Sending', {id, command, data})
             this.port.postMessage({id, command, data});
         })
     }
 
     onMessage(message) {
-        console.log('Received', message);
-        
         if (message.id === undefined) {
             console.warn('Ignoring message from translateLocally that was missing the id', message);
+            return;
         }
-
+        
         const {resolve, reject, update} = this.pending.get(message.id);
 
         if (!message.update)

--- a/extension/controller/translation/WASMTranslationHelper.js
+++ b/extension/controller/translation/WASMTranslationHelper.js
@@ -52,6 +52,13 @@ class WorkerChannel {
  */
  class WASMTranslationHelper {
     
+    /**
+     * options:
+     *   cacheSize: 0
+     *   useNativeIntGemm: false
+     *   workers: 1
+     *   batchSize: 8
+     */
     constructor(options) {
         this.options = options || {};
 

--- a/extension/controller/translation/WASMTranslationHelper.js
+++ b/extension/controller/translation/WASMTranslationHelper.js
@@ -12,8 +12,6 @@ const CACHE_NAME = "bergamot-translations";
 
 const MAX_DOWNLOAD_TIME = 60000; // TODO move this
 
-const MAX_WORKERS = 1;
-
 /**
  * Little wrapper around the message passing API to keep track of messages and
  * their responses in such a way that you can just wait for them by awaiting
@@ -22,7 +20,6 @@ const MAX_WORKERS = 1;
 class WorkerChannel {
     constructor(worker) {
         this.worker = worker;
-        this.worker.onerror = this.onerror.bind(this);
         this.worker.onmessage = this.onmessage.bind(this);
         this.serial = 0;
         this.pending = new Map();
@@ -34,10 +31,6 @@ class WorkerChannel {
             this.pending.set(id, {resolve, reject});
             this.worker.postMessage({id, message});
         })
-    }
-
-    onerror(error) {
-        throw new Error(`Error in worker: ${error.message}`);
     }
 
     onmessage({data: {id, message, error}}) {
@@ -61,7 +54,9 @@ class WorkerChannel {
  */
  class WASMTranslationHelper {
     
-    constructor() {
+    constructor(options) {
+        this.options = options || {};
+
         // registry of all available models and their urls: Promise<List<Model>>
         this.registry = lazy(this.loadModelRegistery.bind(this));
 
@@ -73,6 +68,9 @@ class WorkerChannel {
 
         // List of active workers (and a flag to mark them idle or not)
         this.workers = [];
+
+        // Maximum number of workers
+        this.workerLimit = Math.max(this.options.workers || 0, 1);
 
         // List of batches we push() to & shift() from
         this.queue = [];
@@ -94,8 +92,11 @@ class WorkerChannel {
     loadWorker() {
         // TODO is this really not async? Can I just send messages to it from
         // the start and will they be queued or something?
-        const worker = new Worker('controller/translation/WASMTranslationWorker.js');
-        worker.onerror = (err) => this.onerror(err);
+        const worker = new Worker(browser.runtime.getURL('controller/translation/WASMTranslationWorker.js'));
+        worker.onerror = this.onerror.bind(this);
+
+        // Initialisation options
+        worker.postMessage({options: this.options});
 
         // Little wrapper around the message passing api of Worker to make it
         // easy to await a response to a sent message.
@@ -345,7 +346,7 @@ class WorkerChannel {
             let worker = this.workers.find(worker => worker.idle);
 
             // No worker free, but space for more?
-            if (!worker && this.workers.length < MAX_WORKERS) {
+            if (!worker && this.workers.length < this.workerLimit) {
                 worker = {
                     idle: true,
                     worker: this.loadWorker()

--- a/extension/controller/translation/WASMTranslationWorker.js
+++ b/extension/controller/translation/WASMTranslationWorker.js
@@ -5,11 +5,7 @@
 // Global because importScripts is global.
 var Module = {};
 
-console.log("AAA");
-
 importScripts('yaml.js');
-
-console.log("BBBV");
 
 class WASMTranslationWorker {
     static GEMM_TO_FALLBACK_FUNCTIONS_MAP = {
@@ -225,16 +221,12 @@ class WASMTranslationWorker {
 }
 
 onmessage = ({data}) => {
-    console.debug("WASMTranslationWorker received initial message", data);
-
     if (!data.options){
         console.warn('Did not receive initial message with options');
         return;
     }
 
     const worker = new WASMTranslationWorker(data.options);
-
-    console.log("Made it past");
 
     // Responder for Proxy<Channel> created in TranslationHelper.loadWorker()
     onmessage = async ({data: {id, message}}) => {

--- a/extension/controller/translation/WASMTranslationWorker.js
+++ b/extension/controller/translation/WASMTranslationWorker.js
@@ -24,6 +24,9 @@ class WASMTranslationWorker {
 
     static NATIVE_INT_GEMM = 'mozIntGemm';
 
+    /**
+     * options: {useNativeIntGemm: false, cacheSize: 0}
+     */
     constructor(options) {
         this.options = options || {};
 
@@ -97,7 +100,7 @@ class WASMTranslationWorker {
      */
     async loadTranslationService() {
         const Module = await this.module;
-        return new Module.BlockingService({cacheSize: 20000});
+        return new Module.BlockingService({cacheSize: Math.max(this.options.cacheSize || 0, 0)});
     }
 
     /**

--- a/extension/controller/translation/func.js
+++ b/extension/controller/translation/func.js
@@ -2,14 +2,20 @@
  * Little wrapper to delay a promise to be made only once it is first awaited on
  */
 function lazy(factory) {
+    let promise = null;
+
     return {
         then(...args) {
             // Ask for the actual promise
-            const promise = factory();
-            // Replace ourselves with the actual promise for next calls
-            this.then = promise.then.bind(promise);
+            if (promise === null) {
+                promise = factory();
+            
+                if (typeof promise?.then !== 'function')
+                    throw new TypeError('factory() did not return a promise-like object');
+            }
+
             // Forward the current call to the promise
-            return this.then(...args);
+            return promise.then(...args);
         }
     };
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -76,9 +76,22 @@
 		"32": "/view/icons/translation.32x32.png"
 	},
 	"web_accessible_resources": [
+		"view/static/benchmark.html",
+		"view/static/benchmark.js",
+		"view/static/benchmark.css",
 		"view/static/test.html",
 		"view/static/test.js",
-		"view/js/InPageTranslation.js"
+		"view/js/InPageTranslation.js",
+		"3rd_party/pako/pako_inflate.js",
+		"3rd_party/js-untar/untar.js",
+		"controller/translation/func.js",
+		"controller/translation/promise.js",
+		"controller/translation/yaml.js",
+		"controller/translation/TLTranslationHelper.js",
+		"controller/translation/WASMTranslationHelper.js",
+		"controller/translation/WASMTranslationWorker.js",
+		"controller/translation/bergamot-translation-worker.js",
+		"controller/translation/bergamot-translation-worker.wasm"
 	],
 	"description": "Experimental Bergamot Translations translates any webpage utilizing client based machine learning algorithms and models.",
 	"homepage_url": "https://github.com/jelmervdl/firefox-translations"

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -665,8 +665,6 @@ class InPageTranslation {
      * Batches translation responses for a single big updateElements() call.
      */
     enqueueTranslationResponse(translated, {id}) {
-        console.log('[in-page-translation] Received response to', id);
-        
         // Look up node by message id. This can fail 
         const node = this.pendingTranslations.get(id);
         if (node === undefined) {

--- a/extension/view/static/benchmark.css
+++ b/extension/view/static/benchmark.css
@@ -21,7 +21,7 @@ html, body {
 }
 
 #results .name-col {
-	width: 20em;
+	width: 26em;
 }
 
 #results .startup-col,

--- a/extension/view/static/benchmark.css
+++ b/extension/view/static/benchmark.css
@@ -25,6 +25,7 @@ html, body {
 }
 
 #results .startup-col,
+#results .first-col,
 #results .time-col,
 #results .wps-col {
 	width: 12em;

--- a/extension/view/static/benchmark.css
+++ b/extension/view/static/benchmark.css
@@ -1,0 +1,17 @@
+html, body {
+	font: 14px/18px sans-serif;
+}
+
+.activity-indicator {
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	background: #933;
+	color: white;
+	padding: 0 1em;
+}
+
+.activity-indicator progress {
+/*	margin: 1em 0;*/
+}

--- a/extension/view/static/benchmark.css
+++ b/extension/view/static/benchmark.css
@@ -15,3 +15,22 @@ html, body {
 .activity-indicator progress {
 /*	margin: 1em 0;*/
 }
+
+#results th, #results td {
+	padding: 0.25em 0.5em;
+}
+
+#results .name-col {
+	width: 20em;
+}
+
+#results .startup-col,
+#results .time-col,
+#results .wps-col {
+	width: 12em;
+	text-align: right;
+}
+
+#results .time-col progress {
+	width: 12em;
+}

--- a/extension/view/static/benchmark.css
+++ b/extension/view/static/benchmark.css
@@ -20,8 +20,17 @@ html, body {
 	padding: 0.25em 0.5em;
 }
 
+#results .run td:first-child {
+	text-indent: 2em;
+}
+
+#results .collapse-col {
+	padding: 0.25em 0;
+}
+
 #results .name-col {
 	width: 26em;
+	text-align: left;
 }
 
 #results .startup-col,
@@ -34,4 +43,24 @@ html, body {
 
 #results .time-col progress {
 	width: 12em;
+}
+
+.details-toggle {
+	appearance: none;
+	border-top: .5em solid transparent;
+  border-bottom: .5em solid transparent;
+  border-left: .5em solid currentColor;
+
+  width: 1em;
+  height: 1em;
+  margin: 0;
+  padding: 0;
+  vertical-align: middle;
+  
+  transition: transform .2s ease-out;
+	transform-origin: 25% 50%;
+}
+
+.details-toggle:checked {
+	transform: rotate(90deg);
 }

--- a/extension/view/static/benchmark.html
+++ b/extension/view/static/benchmark.html
@@ -9,7 +9,12 @@
 		<table id="results">
 			<thead>
 				<tr>
-					<th class="name-col">Implementation</th>
+					<th class="collapse-col">
+						<input type="checkbox" class="details-toggle" id="expand-all">
+					</th>
+					<th class="name-col">
+						<label><input type="checkbox" id="enable-all" checked> Scenario</label>
+					</th>
 					<th class="startup-col">Start-up</th>
 					<th class="first-col">First (excl. Start-up)</th>
 					<th class="time-col">Time (excl. Start-up)</th>
@@ -18,12 +23,38 @@
 			</thead>
 			<tbody>
 				<template id="results-row">
-					<tr>
+					<thead>
+						<tr class="summary">
+							<td class="collapse-col">
+								<input type="checkbox" class="details-toggle" data-bind:checked="expanded">
+							</td>
+							<td class="name-col">
+								<label>
+									<input type="checkbox" data-bind:checked="enabled">
+									<span data-bind:text-content="name"></span>
+								</label>
+							</td>
+							<td class="startup-col">
+								<span data-bind:hidden="!startup"><span data-bind:text-content="startup"></span><abbr title="miliseconds">ms</abbr></span>
+							</td>
+							<td class="first-col">
+								<span data-bind:hidden="!first"><span data-bind:text-content="first"></span><abbr title="miliseconds">ms</abbr></span>
+							</td>
+							<td class="time-col">
+								<span data-bind:hidden="!time"><span data-bind:text-content="time"></span><abbr title="miliseconds">ms</abbr></span>
+							</td>
+							<td class="wps-col" data-bind:text-content="wps"></td>
+						</tr>
+					</thead>
+					<tbody data-bind:hidden="hideRuns">
+						<!-- room for runs -->
+					</tbody>
+				</template>
+				<template id="run-row">
+					<tr class="run">
+						<td></td>
 						<td class="name-col">
-							<label>
-								<input type="checkbox" data-bind:checked="enabled">
-								<span data-bind:text-content="name"></span>
-							</label>
+							Run <span data-bind:text-content="run"></span>
 						</td>
 						<td class="startup-col">
 							<span data-bind:hidden="!startup"><span data-bind:text-content="startup"></span><abbr title="miliseconds">ms</abbr></span>
@@ -62,6 +93,7 @@
 						<em>A chunk is a fragment of one or more sentences that is submitted as a single "chunk" to the trranslator.</em>
 					</li>
 				</ul>
+				<li><label>Runs per scenario: <input type="number" data-bind:value="runs" min="1"></label></li>
 				<li><button id="run-test" data-bind:disabled="!texts">Benchmark!</button></li>
 			</ol>
 		</div>

--- a/extension/view/static/benchmark.html
+++ b/extension/view/static/benchmark.html
@@ -6,10 +6,6 @@
 		<link rel="stylesheet" href="benchmark.css">
 	</head>
 	<body>
-		<div class="activity-indicator" data-bind:hidden="!busy">
-			<p><progress></progress> Doing things…</p>
-		</div>
-
 		<table id="results">
 			<thead>
 				<tr>
@@ -23,7 +19,12 @@
 			<tbody>
 				<template id="results-row">
 					<tr>
-						<td class="name-col" data-bind:text-content="name"></td>
+						<td class="name-col">
+							<label>
+								<input type="checkbox" data-bind:checked="enabled">
+								<span data-bind:text-content="name"></span>
+							</label>
+						</td>
 						<td class="startup-col">
 							<span data-bind:hidden="!startup"><span data-bind:text-content="startup"></span><abbr title="miliseconds">ms</abbr></span>
 						</td>
@@ -31,7 +32,7 @@
 							<span data-bind:hidden="!first"><span data-bind:text-content="first"></span><abbr title="miliseconds">ms</abbr></span>
 						</td>
 						<td class="time-col">
-							<progress data-bind:hidden="time" data-bind:value="done" data-bind:max="total"></progress>
+							<progress data-bind:hidden="!busy" data-bind:value="done" data-bind:max="total"></progress>
 							<span data-bind:hidden="!time"><span data-bind:text-content="time"></span><abbr title="miliseconds">ms</abbr></span>
 						</td>
 						<td class="wps-col" data-bind:text-content="wps"></td>
@@ -40,17 +41,30 @@
 			</tbody>
 		</table>
 
-		<ol>
-			<li>Test set: <input type="file" id="test-set-selector" accept="application/xml"><br>
-			    E.g. newstest2021.src.de-en.xml from <a href="http://data.statmt.org/wmt21/translation-task/test-src.tgz">WMT21</a>.</li>
-			<li>
-				<label>From: <input type="text" data-bind:value="from"></label><br>
-				<label>To: <input type="text" data-bind:value="to"></label><br>
-				<label><input type="checkbox" data-bind:checked="html"> input is HTML</label>
-			</li>
-			<li>Total number of words in test set: <em data-bind:text-content="words">to be determined</em></li>
-			<li><button id="run-test" data-bind:disabled="!texts">Benchmark!</button></li>
-		</ol>
+		<div id="controls">
+			<div class="activity-indicator" data-bind:hidden="!busy">
+				<p><progress></progress> Doing things…</p>
+			</div>
+
+			<ol>
+				<li>Test set: <input type="file" id="test-set-selector" accept="application/xml"><br>
+				    E.g. newstest2021.src.de-en.xml from <a href="http://data.statmt.org/wmt21/translation-task/test-src.tgz">WMT21</a>.</li>
+				<li>
+					<label>From: <input type="text" data-bind:value="from"></label><br>
+					<label>To: <input type="text" data-bind:value="to"></label><br>
+					<label><input type="checkbox" data-bind:checked="html"> input is HTML</label>
+				</li>
+				<li>Total number of:</li>
+				<ul>
+					<li>words in test set: <strong data-bind:text-content="words">to be determined</strong></li>
+					<li>
+						chunks in test set: <strong data-bind:text-content="chunks">to be determined</strong><br>
+						<em>A chunk is a fragment of one or more sentences that is submitted as a single "chunk" to the trranslator.</em>
+					</li>
+				</ul>
+				<li><button id="run-test" data-bind:disabled="!texts">Benchmark!</button></li>
+			</ol>
+		</div>
 
 		<script src="../../3rd_party/pako/pako_inflate.js"></script>
 		<script src="../../3rd_party/js-untar/untar.js"></script>

--- a/extension/view/static/benchmark.html
+++ b/extension/view/static/benchmark.html
@@ -13,29 +13,35 @@
 		<table id="results">
 			<thead>
 				<tr>
-					<th>Implementation</th>
-					<th>Time</th>
-					<th>WPS</th>
+					<th class="name-col">Implementation</th>
+					<th class="startup-col">Startup</th>
+					<th class="time-col">Time</th>
+					<th class="wps-col">WPS</th>
 				</tr>
 			</thead>
 			<tbody>
 				<template id="results-row">
 					<tr>
-						<td data-bind:text-content="name"></td>
-						<td>
-							<progress data-bind:hidden="time" data-bind:value="done" data-bind:max="total"></progress>
-							<span data-bind:hidden="!time" data-bind:text-content="time"></span>
+						<td class="name-col" data-bind:text-content="name"></td>
+						<td class="startup-col">
+							<span data-bind:hidden="!startup"><span data-bind:text-content="startup"></span><abbr title="miliseconds">ms</abbr></span>
 						</td>
-						<td data-bind:text-content="wps"></td>
+						<td class="time-col">
+							<progress data-bind:hidden="time" data-bind:value="done" data-bind:max="total"></progress>
+							<span data-bind:hidden="!time"><span data-bind:text-content="time"></span><abbr title="miliseconds">ms</abbr></span>
+						</td>
+						<td class="wps-col" data-bind:text-content="wps"></td>
 					</tr>
 				</template>
 			</tbody>
 		</table>
 
-		<p>Test set: <input type="file" id="test-set-selector" accept="application/xml"></p>
-		<p>Total number of words in test set: <span data-bind:text-content="words">???</span></p>
-
-		<p><button id="run-test" data-bind:disabled="!texts">Run tests</button></p>
+		<ol>
+			<li>Test set: <input type="file" id="test-set-selector" accept="application/xml"><br>
+			    E.g. newstest2021.src.de-en.xml from <a href="http://data.statmt.org/wmt21/translation-task/test-src.tgz">WMT21</a>.</li>
+			<li>Total number of words in test set: <em data-bind:text-content="words">to be determined</em></li>
+			<li><button id="run-test" data-bind:disabled="!texts">Benchmark!</button></li>
+		</ol>
 
 		<script src="../../3rd_party/pako/pako_inflate.js"></script>
 		<script src="../../3rd_party/js-untar/untar.js"></script>

--- a/extension/view/static/benchmark.html
+++ b/extension/view/static/benchmark.html
@@ -15,8 +15,8 @@
 					<th class="name-col">
 						<label><input type="checkbox" id="enable-all" checked> Scenario</label>
 					</th>
-					<th class="startup-col">Start-up</th>
-					<th class="first-col">First (excl. Start-up)</th>
+					<th class="startup-col">Start-up*</th>
+					<th class="first-col">Hot First**</th>
 					<th class="time-col">Time (excl. Start-up)</th>
 					<th class="wps-col">WPS</th>
 				</tr>
@@ -97,6 +97,11 @@
 				<li><button id="run-test" data-bind:disabled="!texts">Benchmark!</button></li>
 			</ol>
 		</div>
+
+		<p>* Start-up is time from instantiation up to the first translated single sentence. We used a single sentence input batch to trigger all the delayed initialisation.</p>
+		<p>** Hot First is time for the first sentence to return after submitting a large batch of sentences. This is a more common scenario for this plugin, since the translation model remains loaded between page loads.</p>
+		<p>Time (excl. start-up) is the total time it takes to translate the test-set, given that the translation model is already loaded and primed.</p>
+		<p>WPS is word count (HTML tags are stripped, excluded elements are stripped as well) divided by the Time column</p>
 
 		<script src="../../3rd_party/pako/pako_inflate.js"></script>
 		<script src="../../3rd_party/js-untar/untar.js"></script>

--- a/extension/view/static/benchmark.html
+++ b/extension/view/static/benchmark.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>Bergamot Browser Benchmark</title>
+		<link rel="stylesheet" href="benchmark.css">
+	</head>
+	<body>
+		<div class="activity-indicator" data-bind:hidden="!busy">
+			<p><progress></progress> Doing things…</p>
+		</div>
+
+		<table id="results">
+			<thead>
+				<tr>
+					<th>Implementation</th>
+					<th>Time</th>
+					<th>WPS</th>
+				</tr>
+			</thead>
+			<tbody>
+				<template id="results-row">
+					<tr>
+						<td data-bind:text-content="name"></td>
+						<td>
+							<progress data-bind:hidden="time" data-bind:value="done" data-bind:max="total"></progress>
+							<span data-bind:hidden="!time" data-bind:text-content="time"></span>
+						</td>
+						<td data-bind:text-content="wps"></td>
+					</tr>
+				</template>
+			</tbody>
+		</table>
+
+		<p>Test set: <input type="file" id="test-set-selector" accept="application/xml"></p>
+		<p>Total number of words in test set: <span data-bind:text-content="words">???</span></p>
+
+		<p><button id="run-test" data-bind:disabled="!texts">Run tests</button></p>
+
+		<script src="../../3rd_party/pako/pako_inflate.js"></script>
+		<script src="../../3rd_party/js-untar/untar.js"></script>
+		<script src="../../controller/translation/func.js"></script>
+		<script src="../../controller/translation/promise.js"></script>
+		<script src="../../controller/translation/yaml.js"></script>
+		<script src="../../controller/translation/TLTranslationHelper.js"></script>
+		<script src="../../controller/translation/WASMTranslationHelper.js"></script>
+		<script src="common.js"></script>
+		<script src="benchmark.js"></script>
+	</body>
+</html>

--- a/extension/view/static/benchmark.html
+++ b/extension/view/static/benchmark.html
@@ -14,8 +14,9 @@
 			<thead>
 				<tr>
 					<th class="name-col">Implementation</th>
-					<th class="startup-col">Startup</th>
-					<th class="time-col">Time</th>
+					<th class="startup-col">Start-up</th>
+					<th class="first-col">First (excl. Start-up)</th>
+					<th class="time-col">Time (excl. Start-up)</th>
 					<th class="wps-col">WPS</th>
 				</tr>
 			</thead>
@@ -25,6 +26,9 @@
 						<td class="name-col" data-bind:text-content="name"></td>
 						<td class="startup-col">
 							<span data-bind:hidden="!startup"><span data-bind:text-content="startup"></span><abbr title="miliseconds">ms</abbr></span>
+						</td>
+						<td class="first-col">
+							<span data-bind:hidden="!first"><span data-bind:text-content="first"></span><abbr title="miliseconds">ms</abbr></span>
 						</td>
 						<td class="time-col">
 							<progress data-bind:hidden="time" data-bind:value="done" data-bind:max="total"></progress>
@@ -39,6 +43,11 @@
 		<ol>
 			<li>Test set: <input type="file" id="test-set-selector" accept="application/xml"><br>
 			    E.g. newstest2021.src.de-en.xml from <a href="http://data.statmt.org/wmt21/translation-task/test-src.tgz">WMT21</a>.</li>
+			<li>
+				<label>From: <input type="text" data-bind:value="from"></label><br>
+				<label>To: <input type="text" data-bind:value="to"></label><br>
+				<label><input type="checkbox" data-bind:checked="html"> input is HTML</label>
+			</li>
 			<li>Total number of words in test set: <em data-bind:text-content="words">to be determined</em></li>
 			<li><button id="run-test" data-bind:disabled="!texts">Benchmark!</button></li>
 		</ol>

--- a/extension/view/static/benchmark.js
+++ b/extension/view/static/benchmark.js
@@ -1,42 +1,50 @@
 // For untar.js
 workerScriptUri = browser.runtime.getURL('3rd_party/js-untar/untar-worker.js');
 
+const defaults = {
+	cacheSize: 0
+};
+
 const implementations = [
 	{
 		name: "WASM, 1 worker",
-		factory: () => new WASMTranslationHelper({workers: 1, useNativeIntGemm: false})
+		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: false})
 	},
 	{
 		name: "WASM, 1 worker, native intgemm",
-		factory: () => new WASMTranslationHelper({workers: 1, useNativeIntGemm: true})
+		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: true})
 	},
 	{
 		name: "WASM, 4 workers",
-		factory: () => new WASMTranslationHelper({workers: 4, useNativeIntGemm: false})
+		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: false})
 	},
 	{
 		name: "WASM, 4 workers, native intgemm, batch-size: 8",
-		factory: () => new WASMTranslationHelper({workers: 4, useNativeIntGemm: true, batchSize: 8})
+		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: true, batchSize: 8})
 	},
 	{
 		name: "WASM, 4 workers, native intgemm, batch-size 16",
-		factory: () => new WASMTranslationHelper({workers: 4, useNativeIntGemm: true, batchSize: 16})
+		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: true, batchSize: 16})
 	},
 	{
 		name: "WASM, 4 workers, native intgemm, batch-size 32",
-		factory: () => new WASMTranslationHelper({workers: 4, useNativeIntGemm: true, batchSize: 32})
+		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: true, batchSize: 32})
 	},
 	{
 		name: "WASM, 4 workers, native intgemm, batch-size 128",
-		factory: () => new WASMTranslationHelper({workers: 4, useNativeIntGemm: true, batchSize: 128})
+		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: true, batchSize: 128})
 	},
 	{
 		name: "WASM, 4 workers, native intgemm, batch-size 256",
-		factory: () => new WASMTranslationHelper({workers: 4, useNativeIntGemm: true, batchSize: 256})
+		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: true, batchSize: 256})
 	},
 	{
-		name: "Native Messaging",
-		factory: () => new TLTranslationHelper()
+		name: "Native Messaging, 1 worker",
+		factory: () => new TLTranslationHelper({...defaults, workers: 1})
+	},
+	{
+		name: "Native Messaging, 4 workers",
+		factory: () => new TLTranslationHelper({...defaults, workers: 4})
 	},
 ];
 

--- a/extension/view/static/benchmark.js
+++ b/extension/view/static/benchmark.js
@@ -48,7 +48,7 @@ const implementations = [
 		factory: () => new TLTranslationHelper({...defaults, workers: 4})
 	},
 	{
-		name: "WASM, 1 worker, batch-size: 16, cache-size: 20000",
+		name: "WASM, 1 worker, batch-size: 8, cache-size: 20000",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: false, batchSize: 16, cacheSize: 20000})
 	},
 	

--- a/extension/view/static/benchmark.js
+++ b/extension/view/static/benchmark.js
@@ -198,12 +198,14 @@ async function execute(scenario, run) {
 	const init = performance.now();
 
 	const translator = scenario.implementation.factory();
-	// await translator.translate({
-	// 	from: state.from,
-	// 	to: state.to,
-	// 	text: 'This is a warm-up sentence.',
-	// 	html: false
-	// });
+
+	// Warm-up sentence
+	await translator.translate({
+		from: state.from,
+		to: state.to,
+		text: 'Hallo welt!',
+		html: false
+	});
 	
 	const start = performance.now();
 
@@ -224,7 +226,7 @@ async function execute(scenario, run) {
 	await Promise.any(promises); // any() instead of race() because I want a response, not an error
 	data.first = performance.now() - start;
 
-	await Promise.all(promises);
+	await Promise.allSettled(promises);
 	data.time = performance.now() - start;
 
 	data.wps = Math.round(state.words / (data.time / 1000));
@@ -235,13 +237,13 @@ async function execute(scenario, run) {
 }
 
 function updateAverages(scenario) {
-	for (let column of ['startup', 'first', 'time']) {
+	for (let column of ['startup', 'first', 'time', 'wps']) {
 		scenario.data[column] = Math.round(scenario.runs.reduce((acc, {data}) => acc + data[column], 0) / scenario.runs.length);
 	}
 }
 
 function updateBarChart() {
-	for (let column of ['startup', 'first', 'time']) {
+	for (let column of ['startup', 'first', 'time', 'wps']) {
 		const max = scenarios.filter(({data: {enabled}}) => enabled).reduce((acc, {data}) => Math.max(acc, data[column]), 0);
 
 		for (let {row, data} of scenarios) {

--- a/extension/view/static/benchmark.js
+++ b/extension/view/static/benchmark.js
@@ -1,0 +1,144 @@
+// For untar.js
+workerScriptUri = browser.runtime.getURL('3rd_party/js-untar/untar-worker.js');
+
+const implementations = [
+	{
+		name: "WASM, 1 worker",
+		factory: () => new WASMTranslationHelper({workers: 1, useNativeIntGemm: false})
+	},
+	{
+		name: "WASM, 1 worker, native intgemm",
+		factory: () => new WASMTranslationHelper({workers: 1, useNativeIntGemm: true})
+	},
+	{
+		name: "WASM, 4 workers",
+		factory: () => new WASMTranslationHelper({workers: 4, useNativeIntGemm: false})
+	},
+	{
+		name: "Native Messaging",
+		factory: () => new TLTranslationHelper()
+	},
+];
+
+async function run({implementation, texts, from , to, update}) {
+	performance.mark('start-scenario');
+	const translator = implementation.factory();
+	await translator.translate({from, to, text: 'This is a warm-up sentence.', html: false});
+	performance.measure('scenario-loaded', 'start-scenario');
+
+	const start = performance.now();
+
+	let total = 0;
+	let done = 0;
+
+	await Promise.all(texts.map(async text => {
+		update(done, ++total);
+		await translator.translate({from, to, text, html: false});
+		update(++done, total);
+	}));
+
+	return performance.now() - start;
+}
+
+function readFileAsText(file) {
+	return new Promise((accept, reject) => {
+		const reader = new FileReader();
+		reader.addEventListener('load', e => {
+			accept(reader.result);
+		});
+		reader.readAsText(file);
+	})
+}
+
+async function readTestSet(file) {
+	const parser = new DOMParser();
+	
+	const document = parser.parseFromString(await readFileAsText(file), 'application/xml');
+
+	const texts = [];
+
+	document.querySelectorAll('dataset > doc > src > p').forEach(p => {
+		const segments = [];
+		p.querySelectorAll('seg').forEach(seg => {
+			segments.push(seg.textContent);
+		});
+		texts.push(segments.join(' '));
+	});
+
+	return texts;
+}
+
+function observe(obj, callback) {
+	return new Proxy(obj, {
+		get(target, prop, receiver) {
+			const val = Reflect.get(target, prop);
+
+			if (prop === 'prototype')
+				return val;
+
+			try {
+				return new Proxy(val, this);
+			} catch (e) {
+				if (e instanceof TypeError)
+					return val;
+				else
+					throw e;
+			}
+		},
+		set(target, prop, value) {
+			target[prop] = value;
+			callback(obj);
+			return true;
+		}
+	});
+}
+
+const state = observe({
+	busy: false,
+	texts: [],
+	words: null,
+}, renderBoundElements.bind(document.body));
+
+renderBoundElements(state);
+
+addEventListeners({
+	'input #test-set-selector': e => {
+		Array.from(e.target.files).forEach(async file => {
+			state.busy = true;
+			state.texts = (await readTestSet(file)).slice(0, 250);
+			state.words = state.texts.reduce((words, text) => words + text.split(/\b\W+\b/).length, 0);
+			state.busy = false;
+		});
+	},
+	'click #run-test': async e => {
+		for (let implementation of implementations) {
+			const row = document.querySelector('#results-row').content.firstElementChild.cloneNode(true);
+			document.querySelector('#results tbody').appendChild(row);
+
+			const render = renderBoundElements.bind(row);
+
+			const data = observe({
+				name: implementation.name,
+				time: null,
+				wps: null,
+				done: 0,
+				total: 0
+			}, debounce(render));
+
+			render(data);
+
+			data.time = await run({
+				implementation,
+				texts: state.texts,
+				from: 'de',
+				to: 'en',
+				update: (done, total) => {
+					data.done = done;
+					data.total = total;
+				}
+			});
+
+			data.wps = state.words / (data.time / 1000);
+		}
+	}
+});

--- a/extension/view/static/benchmark.js
+++ b/extension/view/static/benchmark.js
@@ -213,6 +213,27 @@ addEventListeners({
 
 			data.busy = false;
 		}
+
+		// Let's draw a bar because I can!
+		for (let column of ['startup', 'first', 'time']) {
+			const max = results.filter(({data: {enabled}}) => enabled).reduce((acc, {data}) => Math.max(acc, data[column]), 0);
+
+			for (let {row, data} of results) {
+				const cell = row.querySelector(`.${column}-col`);
+
+				if (!data.enabled) {
+					cell.style.backgroundImage = '';
+					continue;
+				}
+				const percentage = (100 * data[column] / max).toFixed(0);
+				cell.style.backgroundImage = `linear-gradient(90deg,
+					rgba(  0,  0,255,0.1) 0%,
+					rgba(  0,  0,255,0.1) ${percentage}%,
+					rgba(255,255,255,0.0) ${percentage}%,
+					rgba(255,255,255,0.0) 100%)`;
+			}
+		}
+
 		state.busy = false;
 	}
 });

--- a/extension/view/static/benchmark.js
+++ b/extension/view/static/benchmark.js
@@ -7,15 +7,19 @@ const defaults = {
 
 const implementations = [
 	{
-		name: "WASM, 1 worker",
-		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: false})
+		name: "WASM, 1 worker, batch-size: 8",
+		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: false, batchSize: 8})
 	},
 	{
-		name: "WASM, 1 worker, native intgemm",
+		name: "WASM, 1 worker, batch-size: 16",
+		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: false, batchSize: 16})
+	},
+	{
+		name: "WASM, 1 worker, native intgemm, batch-size: 8",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: true})
 	},
 	{
-		name: "WASM, 4 workers",
+		name: "WASM, 4 workers, batch-size: 8",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: false})
 	},
 	{
@@ -46,6 +50,11 @@ const implementations = [
 		name: "Native Messaging, 4 workers",
 		factory: () => new TLTranslationHelper({...defaults, workers: 4})
 	},
+	{
+		name: "WASM, 1 worker, batch-size: 16, cache-size: 20000",
+		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: false, batchSize: 16, cacheSize: 20000})
+	},
+	
 ];
 
 function readFileAsText(file) {

--- a/extension/view/static/benchmark.js
+++ b/extension/view/static/benchmark.js
@@ -1,6 +1,3 @@
-// For untar.js
-workerScriptUri = browser.runtime.getURL('3rd_party/js-untar/untar-worker.js');
-
 const defaults = {
 	cacheSize: 0
 };

--- a/extension/view/static/benchmark.js
+++ b/extension/view/static/benchmark.js
@@ -4,54 +4,65 @@ const defaults = {
 
 const implementations = [
 	{
+		enabled: true,
 		name: "WASM, 1 worker, batch-size: 8",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: false, batchSize: 8})
 	},
 	{
+		enabled: true,
+		name: "WASM, 1 worker, batch-size: 8, cache-size: 20000",
+		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: false, batchSize: 16, cacheSize: 20000})
+	},
+	{
+		enabled: false,
 		name: "WASM, 1 worker, batch-size: 16",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: false, batchSize: 16})
 	},
 	{
+		enabled: true,
 		name: "WASM, 1 worker, native intgemm, batch-size: 8",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: true})
 	},
 	{
+		enabled: true,
 		name: "WASM, 4 workers, batch-size: 8",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: false})
 	},
 	{
+		enabled: true,
 		name: "WASM, 4 workers, native intgemm, batch-size: 8",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: true, batchSize: 8})
 	},
 	{
+		enabled: false,
 		name: "WASM, 4 workers, native intgemm, batch-size 16",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: true, batchSize: 16})
 	},
 	{
+		enabled: false,
 		name: "WASM, 4 workers, native intgemm, batch-size 32",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: true, batchSize: 32})
 	},
 	{
+		enabled: false,
 		name: "WASM, 4 workers, native intgemm, batch-size 128",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: true, batchSize: 128})
 	},
 	{
+		enabled: false,
 		name: "WASM, 4 workers, native intgemm, batch-size 256",
 		factory: () => new WASMTranslationHelper({...defaults, workers: 4, useNativeIntGemm: true, batchSize: 256})
 	},
 	{
+		enabled: true,
 		name: "Native Messaging, 1 worker",
 		factory: () => new TLTranslationHelper({...defaults, workers: 1})
 	},
 	{
+		enabled: true,
 		name: "Native Messaging, 4 workers",
 		factory: () => new TLTranslationHelper({...defaults, workers: 4})
 	},
-	{
-		name: "WASM, 1 worker, batch-size: 8, cache-size: 20000",
-		factory: () => new WASMTranslationHelper({...defaults, workers: 1, useNativeIntGemm: false, batchSize: 16, cacheSize: 20000})
-	},
-	
 ];
 
 function readFileAsText(file) {
@@ -153,7 +164,7 @@ const scenarios = implementations.map(implementation => {
 	document.querySelector('#results').appendChild(section);
 
 	const data = observe({
-		enabled: true,
+		enabled: implementation.enabled,
 		expanded: false,
 		busy: false,
 		name: implementation.name,

--- a/extension/view/static/common.js
+++ b/extension/view/static/common.js
@@ -128,3 +128,12 @@ function debounce(callable) {
 		}
 	};
 }
+
+async function* asCompleted(iterable) {
+	const promises = new Set(iterable);
+	while (promises.size() > 0) {
+		const next = await Promise.race(promises);
+		yield next;
+		promises.delete(next);
+	}
+}

--- a/extension/view/static/common.js
+++ b/extension/view/static/common.js
@@ -1,6 +1,8 @@
 function addEventListeners(handlers) {
 	const handlersPerEventType = {};
 
+	const root = this instanceof Element ? this : document.body;
+
 	Object.entries(handlers).forEach(([name, callback]) => {
 		const [event, selector] = name.split(' ', 2);
 		if (!(event in handlersPerEventType))
@@ -9,7 +11,7 @@ function addEventListeners(handlers) {
 	});
 
 	Object.entries(handlersPerEventType).forEach(([event, handlers]) => {
-		document.body.addEventListener(event, e => {
+		root.addEventListener(event, e => {
 			handlers.forEach(({selector, callback}) => {
 				if (e.target.matches(selector))
 					callback(e);
@@ -85,7 +87,7 @@ function renderBoundElements(state) {
 }
 
 function addBoundElementListeners(callback) {
-	addEventListeners({
+	addEventListeners.call(this, {
 		'change *[data-bind\\:value]': e => {
 			callback(e.target.dataset['bind:value'], e.target.value, e);
 		},

--- a/extension/view/static/common.js
+++ b/extension/view/static/common.js
@@ -72,7 +72,8 @@ function renderBoundElements(state) {
 						} else {
 							if (!(value in stateProxy))
 								console.warn('render state has no key', value);
-							el[match[1]] = stateProxy[value];
+							else if (typeof stateProxy[value] !== 'undefined')
+								el[match[1]] = stateProxy[value];
 						}
 						break;
 				}

--- a/extension/view/static/common.js
+++ b/extension/view/static/common.js
@@ -99,8 +99,8 @@ class BoundElementRenderer {
 	}
 }
 
-function renderBoundElements(state) {
-	return new BoundElementRenderer(this).render(state);
+function renderBoundElements(root, state) {
+	return new BoundElementRenderer(root).render(state);
 }
 
 function addBoundElementListeners(root, callback) {

--- a/extension/view/static/options.html
+++ b/extension/view/static/options.html
@@ -2,17 +2,36 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <style>
+      body {
+        font-size: 1.2rem;
+      }
+      .panel-formElements-item {
+        flex-wrap: wrap;
+      }
+      .panel-formElements-item p {
+        flex: 0 0 100%;
+        font-size: 1rem;
+      }
+    </style>
   </head>
   <body>
     <div class="panel-section panel-section-formElements">
       <div class="panel-formElements-item">
-        <label for="translation-provider">Translation provider</label>
+        <label for="translation-provider">Translation provider:</label>
         <select id="translation-provider" data-bind:value="provider">
           <option value="wasm">WASM (embedded)</option>
           <option value="translatelocally" data-bind:disabled="!translateLocallyAvailable">TranslateLocally</option>
         </select>
+        <p data-bind:hidden="translateLocallyAvailable">You can <a href="https://translatelocally.com">download TranslateLocally</a> for even faster private translations.</p>
       </div>
-      <p data-bind:hidden="translateLocallyAvailable">You can <a href="https://translatelocally.com">download TranslateLocally</a> for even faster private translations.</p>
+    </div>
+    <div class="panel-section panel-section-formElements">
+      <div class="panel-formElements-item browser-style">
+        <input id="show-developer-toggle" type="checkbox" data-bind:checked="developer" class="browser-style">
+        <label for="show-developer-toggle">Show developer options</label>
+        <p>Mainly useful for benchmarking and debugging. <a data-bind:href="benchmarkURL" target="blank_">Benchmark page</a></p>
+      </div>
     </div>
     <script src="common.js"></script>
     <script src="options.js"></script>

--- a/extension/view/static/options.js
+++ b/extension/view/static/options.js
@@ -17,7 +17,7 @@ browser.storage.onChanged.addListener(async changes => {
 	renderBoundElements(state);
 });
 
-addBoundElementListeners((key, value) => {
+addBoundElementListeners(document.body, (key, value) => {
 	browser.storage.local.set({[key]: value});
 });
 
@@ -29,6 +29,6 @@ port.onDisconnect.addListener(e => {
 	} else {
 		state.translateLocallyAvailable = true;
 	}
-	renderBoundElements(state);
+	renderBoundElements(document.body, state);
 })
 port.disconnect();

--- a/extension/view/static/options.js
+++ b/extension/view/static/options.js
@@ -2,7 +2,11 @@
 
 const state = {
 	provider: 'wasm',
-	translateLocallyAvailable: false
+	translateLocallyAvailable: false,
+	recorder: false,
+	get benchmarkURL() {
+		return browser.runtime.getURL('view/static/benchmark.html');
+	}
 };
 
 browser.storage.local.get().then(localState => {

--- a/extension/view/static/options.js
+++ b/extension/view/static/options.js
@@ -7,14 +7,14 @@ const state = {
 
 browser.storage.local.get().then(localState => {
 	Object.assign(state, localState);
-	renderBoundElements(state);
+	renderBoundElements(document.body, state);
 });
 
 browser.storage.onChanged.addListener(async changes => {
 	Object.entries(changes).forEach(([key, {newValue}]) => {
 		state[key] = newValue;
 	});
-	renderBoundElements(state);
+	renderBoundElements(document.body, state);
 });
 
 addBoundElementListeners(document.body, (key, value) => {

--- a/extension/view/static/options.js
+++ b/extension/view/static/options.js
@@ -1,9 +1,9 @@
 // Defaults. Duplicated in backgroundScript.js :(
 
-const state = new Proxy({
+const state = {
 	provider: 'wasm',
 	translateLocallyAvailable: false
-}, StateHelper);
+};
 
 browser.storage.local.get().then(localState => {
 	Object.assign(state, localState);

--- a/extension/view/static/popup.html
+++ b/extension/view/static/popup.html
@@ -74,11 +74,11 @@
 			Enable debug mode
 		</label>
 		<label>
-			<a data-bind:href="benchmarkURL" target="blank_">Benchmark</a>
+			<input type="checkbox" data-bind:checked="record">
+			Record pages <a href="#" id="export-recorded-pages-btn" data-bind:hidden="!canExportPages">Export <span data-bind:text-content="recordedPagesCount"></span> pages</button>
 		</label>
 		<label>
-			<button id="export-recorded-pages-btn">Export recorded pages</button>
-			<a data-bind:hidden="!recordedPagesURL" data-bind:href="recordedPagesURL" download="recored-pages.xml">Download <span data-bind:text-content="recordedPagesCount"></span> recorded pages as xml</a>
+			<a data-bind:href="benchmarkURL" target="blank_">Benchmark</a>
 		</label>
 		<script src="common.js"></script>
 		<script src="popup.js"></script>

--- a/extension/view/static/popup.html
+++ b/extension/view/static/popup.html
@@ -73,6 +73,9 @@
 			<input type="checkbox" data-bind:checked="debug">
 			Enable debug mode
 		</label>
+		<label>
+			<a data-bind:href="benchmarkURL" target="blank_">Benchmark</a>
+		</label>
 		<script src="common.js"></script>
 		<script src="popup.js"></script>
 	</body>

--- a/extension/view/static/popup.html
+++ b/extension/view/static/popup.html
@@ -69,16 +69,14 @@
 				<p><code id="error-message" data-bind:text-content="error"></code></p>
 			</div>
 		</div>
-		<label>
+		<label data-bind:hidden="!developer" title="Renders coloured borders around sections identified by the in-page translation code">
 			<input type="checkbox" data-bind:checked="debug">
-			Enable debug mode
+			Draw translation sections
 		</label>
-		<label>
+		<label data-bind:hidden="!developer" title="Records translation requests made to the translation provider. These can be exported as XML.">
 			<input type="checkbox" data-bind:checked="record">
-			Record pages <a href="#" id="export-recorded-pages-btn" data-bind:hidden="!canExportPages">Export <span data-bind:text-content="recordedPagesCount"></span> pages</button>
-		</label>
-		<label>
-			<a data-bind:href="benchmarkURL" target="blank_">Benchmark</a>
+			Record translation requests
+			<a href="#" id="export-recorded-pages-btn" data-bind:hidden="!canExportPages">Export <span data-bind:text-content="recordedPagesCount"></span> pages</button>
 		</label>
 		<script src="common.js"></script>
 		<script src="popup.js"></script>

--- a/extension/view/static/popup.html
+++ b/extension/view/static/popup.html
@@ -76,6 +76,10 @@
 		<label>
 			<a data-bind:href="benchmarkURL" target="blank_">Benchmark</a>
 		</label>
+		<label>
+			<button id="export-recorded-pages-btn">Export recorded pages</button>
+			<a data-bind:hidden="!recordedPagesURL" data-bind:href="recordedPagesURL" download="recored-pages.xml">Download <span data-bind:text-content="recordedPagesCount"></span> recorded pages as xml</a>
+		</label>
 		<script src="common.js"></script>
 		<script src="popup.js"></script>
 	</body>

--- a/extension/view/static/popup.js
+++ b/extension/view/static/popup.js
@@ -25,8 +25,8 @@ function render(state) {
 		'lang-from-options': new Map(state.page.models.map(({from}) => [from, name(from)])),
 		'lang-to-options': new Map(state.page.models.filter(model => from === model.from).map(({to, pivot}) => [to, name(to) + (pivot ? ` (via ${name(pivot)})` : '')])),
 		'needs-download': needsDownload,
-		'!needs-download': !needsDownload, // data-bind has no operators, so ! goes in the name :P
-		'completedTranslationRequests': state.totalTranslationRequests - state.pendingTranslationRequests || undefined
+		'completedTranslationRequests': state.totalTranslationRequests - state.pendingTranslationRequests || undefined,
+		'benchmarkURL': browser.runtime.getURL('view/static/benchmark.html')
 	};
 
 	// Toggle "hidden" state of all <div data-state=""> elements

--- a/extension/view/static/popup.js
+++ b/extension/view/static/popup.js
@@ -96,6 +96,11 @@ browser.tabs.query({active: true, currentWindow: true}).then(tabs => {
 			backgroundScript.postMessage({
 				command: 'TranslateAbort'
 			});
+		},
+		'click #export-recorded-pages-btn': e => {
+			backgroundScript.postMessage({
+				command: 'ExportRecordedPages'
+			});
 		}
 	});
 });

--- a/extension/view/static/popup.js
+++ b/extension/view/static/popup.js
@@ -1,12 +1,30 @@
 const regionNamesInEnglish = new Intl.DisplayNames([...navigator.languages, 'en'], {type: 'language'});
 
-function render(state) {
+// Tab state
+const tabState = {};
+
+// Plugin state, like configuration mostly
+const globalState = {};
+
+// Init global state
+browser.storage.local.get(['developer']).then(state => {
+	Object.assign(globalState, state);
+});
+
+browser.storage.onChanged.addListener(changes => {
+    Object.entries(changes).forEach(([key, {newValue}]) => {
+        globalState[key] = newValue;
+    });
+    render();
+});
+
+function render() {
 	// Shortcuts, I use these everywhere
-	const from = state.from || state.page.from;
-	const to = state.to || state.page.to;
+	const from = tabState.from || tabState.page?.from;
+	const to = tabState.to || tabState.page?.to;
 
 	// If the model (or one of the models in case of pivoting) needs downloading
-	const needsDownload = state.page.models.find(model => from === model.from && to === model.to)?.models?.some(({model}) => !model.local);
+	const needsDownload = tabState.page?.models?.find(model => from === model.from && to === model.to)?.models?.some(({model}) => !model.local);
 
 	const name = (code) => {
 		try {
@@ -17,22 +35,22 @@ function render(state) {
 	};
 
 	const renderState = {
-		...state,
+		...globalState,
+		...tabState,
 		from,
 		to,
 		'lang-from': regionNamesInEnglish.of(from),
 		'lang-to': regionNamesInEnglish.of(to),
-		'lang-from-options': new Map(state.page.models.map(({from}) => [from, name(from)])),
-		'lang-to-options': new Map(state.page.models.filter(model => from === model.from).map(({to, pivot}) => [to, name(to) + (pivot ? ` (via ${name(pivot)})` : '')])),
+		'lang-from-options': new Map(tabState.page?.models.map(({from}) => [from, name(from)])),
+		'lang-to-options': new Map(tabState.page?.models.filter(model => from === model.from).map(({to, pivot}) => [to, name(to) + (pivot ? ` (via ${name(pivot)})` : '')])),
 		'needs-download': needsDownload,
-		'completedTranslationRequests': state.totalTranslationRequests - state.pendingTranslationRequests || undefined,
-		'benchmarkURL': browser.runtime.getURL('view/static/benchmark.html'),
-		'canExportPages': state.recordedPagesCount > 0,
+		'completedTranslationRequests': tabState.totalTranslationRequests - tabState.pendingTranslationRequests || undefined,
+		'canExportPages': tabState.recordedPagesCount > 0,
 	};
 
 	// Toggle "hidden" state of all <div data-state=""> elements
 	document.querySelectorAll('*[data-state]').forEach(el => {
-		el.hidden = el.dataset.state != renderState.state;
+		el.hidden = el.dataset.state != tabState.state;
 	});
 
 	renderBoundElements(document.body, renderState);
@@ -58,13 +76,11 @@ browser.tabs.query({active: true, currentWindow: true}).then(tabs => {
 
 	const backgroundScript = browser.runtime.connect({name: `popup-${tabId}`});
 
-	const state = {};
-
 	backgroundScript.onMessage.addListener(({command, data}) => {
 		switch (command) {
 			case 'Update':
-				Object.assign(state, data);
-				render(state);
+				Object.assign(tabState, data);
+				render();
 				break;
 			case 'DownloadRecordedPages':
 				download(data.url, data.name);
@@ -84,21 +100,21 @@ browser.tabs.query({active: true, currentWindow: true}).then(tabs => {
 			backgroundScript.postMessage({
 				command: 'TranslateStart',
 				data: {
-					from: state.from || state.page.from,
-					to: state.to || state.page.to
+					from: tabState.from || tabState.page.from,
+					to: tabState.to || tabState.page.to
 				}
 			});
 		},
 		'click #download-btn': e => {
 			const data = {
-				from: state.from || state.page.from,
-				to: state.to || state.page.to
+				from: tabState.from || tabState.page.from,
+				to: tabState.to || tabState.page.to
 			};
 
-			// TODO this assumes state.from and state.to reflect the current UI,
+			// TODO this assumes tabState.from and tabState.to reflect the current UI,
 			// which they should iff the UpdateRequest has been processed and
 			// broadcasted by backgroundScript.
-			data.models = state.page.models
+			data.models = tabState.page.models
 			              .find(({from, to}) => from === data.from && to === data.to)
 			              .models
 			              .map(({model}) => model.id);

--- a/extension/view/static/popup.js
+++ b/extension/view/static/popup.js
@@ -34,7 +34,7 @@ function render(state) {
 		el.hidden = el.dataset.state != renderState.state;
 	});
 
-	renderBoundElements(renderState);
+	renderBoundElements(document.body, renderState);
 }
 
 // Query which tab we represent and then connect to the tab state in the 
@@ -56,14 +56,14 @@ browser.tabs.query({active: true, currentWindow: true}).then(tabs => {
 		}
 	});
 
-	addBoundElementListeners((key, value) => {
+	addBoundElementListeners(document.body, (key, value) => {
 		backgroundScript.postMessage({
 			command: 'UpdateRequest',
 			data: {[key]: value}
 		});
 	});
 
-	addEventListeners({
+	addEventListeners(document.body, {
 		'click #translate-btn': e => {
 			backgroundScript.postMessage({
 				command: 'TranslateStart',


### PR DESCRIPTION
Adds a benchmarking page to the extension, as an "easy" way to get some numbers. Having the benchmarking page in the extension is not entirely necessary, but since development of upstream stuff is the raison d'être of this thing, might as well maintain it. It does give more finegrained control over performance tuning, so that's cool.

![image](https://user-images.githubusercontent.com/198639/166938790-52a7f89b-50e7-4d84-96d6-255848216a87.png)

Tested on Firefox Nightly 102, 2019 Macbook 16” 2.3 GHz 8-core (but only 4 used in test) Intel i9, [5 runs per scenario](https://user-images.githubusercontent.com/198639/166939230-4bb08a67-ce5f-4565-8a50-4f9c03fd08f8.png)

Test set: [recored-pages(2).xml.zip](https://github.com/jelmervdl/firefox-translations/files/8620805/recored-pages.2.xml.zip) which is me browsing German Wikipedia and Der Spiegel for a bit.

Its hardcoded to _de-en_ and it does not check whether it is using the same models. But it is getting the models from the same TranslateLocally repository, and it has the same heuristic as TranslateLocally: _locally_ is preferred, then _tiny_ is preferred.

In the addon options, you can turn on "developer mode" (or whatever I called it). This then adds a "record translation requests" toggle in the translation popup. When you tick that, it will start recording all translation requests from that point on. You can click the "Export xml" link next to the checkbox to get the recording. This also clears the recorder again.

Then, also in the addon settings, there is a link to the benchmark page. Upload the recording you just downloaded there, and you can run it on multiple scenarios.