### PR TITLE
Restore page after InPageTranslation

### DIFF
--- a/extension/controller/contentScript.js
+++ b/extension/controller/contentScript.js
@@ -39,7 +39,7 @@ on('Update', diff => {
                 break;
             
             default:
-                inPageTranslation.stop();
+                inPageTranslation.restore();
                 break;
         }
     }

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -329,6 +329,8 @@ class InPageTranslation {
         if (!this.started)
             return;
 
+        this.started = false;
+
         // TODO: cancel translation requests? Not really necessary at this level
         // because stop() is called on disconnect from the background-script,
         // and that script on its own will cancel translation requests from
@@ -347,7 +349,15 @@ class InPageTranslation {
 
         this.pendingTranslations.clear();
 
-        this.started = false;
+        // Remove any pending node updates for which we just received a
+        // translation but haven't update the node yet.
+        this.translatedNodes.clear();
+
+        // Also make sure we don't attempt to update pending nodes anymore.
+        if (this.updateTimeout) {
+            clearTimeout(this.updateTimeout)
+            this.updateTimeout = null;
+        }
     }
 
     /**
@@ -893,6 +903,8 @@ class InPageTranslation {
             else
                 node.data = translated;
         };
+
+        console.assert(this.started, 'Called updateElements while InPageTranslation.started is false');
 
         // Pause observing mutations
         this.stopMutationObserver();

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -241,12 +241,12 @@ class InPageTranslation {
                             if (mutation.addedNodes) {
                                 if (mutation.previousSibling) {
                                     let index = children.indexOf(mutation.previousSibling)
-                                    console.assert(index !== -1, 'index of previous sibling not found');
+                                    console.assert(index !== -1, 'index of previous sibling', mutation.previousSibling, 'not found in', Array.from(children));
                                     children.splice(index + 1, 0, ...mutation.addedNodes);
                                 }
                                 else if (mutation.nextSibling) {
                                     let index = children.indexOf(mutation.nextSibling);
-                                    console.assert(index !== -1, 'index of next sibling not found');
+                                    console.assert(index !== -1, 'index of next sibling', mutation.nextSibling, 'not found in', Array.from(children));
                                     children.splice(index, 0, ...mutation.addedNodes);
                                 }
                                 else {

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -102,7 +102,7 @@ class InPageTranslation {
 
         // Timeout between first DOM mutation and us re-evaluating these nodes.
         this.restartTimeout = null;
-        this.RESTART_INTERVAL = 100;
+        this.RESTART_INTERVAL = 20;
 
         // Table of [Element]:Object to be submitted, and some info about them.
         // Filled by enqueueTranslation(), emptied by dispatchTranslation().

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -175,7 +175,7 @@ class InPageTranslation {
 
                             mutation.removedNodes.forEach(child => {
                                 let index = children.indexOf(child);
-                                console.assert(index !== -1, 'could not find removed node among children', index, children[0] === child);
+                                console.assert(index !== -1, 'could not find removed node among children', child, Array.from(children));
                                 if (index !== -1) children.splice(index, 1);
                             });
 
@@ -191,7 +191,7 @@ class InPageTranslation {
                                     children.splice(index, 0, ...mutation.addedNodes);
                                 }
                                 else {
-                                    console.assert(children.length === 0, 'no next/prev sibling but the original node had children')
+                                    console.assert(children.length === 0, 'no next/prev sibling but the original node had children', Array.from(children))
                                     children.splice(0, 0, ...mutation.addedNodes);
                                 }
                             }

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -706,6 +706,8 @@ class InPageTranslation {
                     // they'll only cause mismatches between textual text nodes.
                     if (child.data.trim().length == 0)
                         return false;
+
+                    return true;
                 });
 
                 const dstChildNodes = Object.fromEntries(dstNodes

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -496,7 +496,7 @@ class InPageTranslation {
 
         // Based on jQuery (talk about battle-tested...)
         // https://github.com/jquery/jquery/blob/main/src/css/hiddenVisibleSelectors.js
-        return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+        return element && !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
     }
 
     /**

--- a/extension/view/js/InPageTranslation.js
+++ b/extension/view/js/InPageTranslation.js
@@ -126,9 +126,8 @@ class InPageTranslation {
         this.targetNodes = new Set();
 
         // Per Element we store a list of the original children, or per TextNode
-        // we store the original text.
-        this.originalContent = new Map(); //new EnumerableWeakMap();
-
+        // we store the original text. Needs to be enumerable, so no WeakMap.
+        this.originalContent = new Map(); //new EnumerableWeakMap(); but that doesn't work because of a privilege boundary.
         // Reference for all tags:
         // https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 

--- a/extension/view/static/test.html
+++ b/extension/view/static/test.html
@@ -11,10 +11,11 @@
 	</head>
 	<body>
 		<div id="controls" translate="no">
+			<button id="run">Run</button>
 			<button id="toggle">Start</button>
+			<button id="restore">Restore</button>
 			<button id="translate-head">Translate head</button>
 			<button id="translate-tail">Translate tail</button>
-			<button id="restore">Restore</button>
 			<span id="status"></span>
 		</div>
 

--- a/extension/view/static/test.html
+++ b/extension/view/static/test.html
@@ -14,6 +14,7 @@
 			<button id="toggle">Start</button>
 			<button id="translate-head">Translate head</button>
 			<button id="translate-tail">Translate tail</button>
+			<button id="restore">Restore</button>
 			<span id="status"></span>
 		</div>
 

--- a/extension/view/static/test.js
+++ b/extension/view/static/test.js
@@ -1,3 +1,80 @@
+/**
+ * Queue class that supports an overly complicated way of waiting for
+ * certain conditions in the queue. Think of it as something someone
+ * familiar with multithreading producer/consumer queues would built
+ * when given async/await.
+ */
+class Queue extends Array {
+	#pendingConditions = [];
+
+	#pendingMutations = [];
+
+	push(...args) {
+		return super.push(...args);
+	}
+
+	pop() {
+		return this.#checkAfterwards(() => super.pop());
+	}
+
+	shift() {
+		return this.#checkAfterwards(() => super.shift());
+	}
+
+	reset() {
+		return this.#checkAfterwards(() => this.splice(0, this.length));
+	}
+
+	#checkAfterwards(inner) {
+		const retval = inner();
+		
+		this.#pendingConditions = this.#pendingConditions.filter(({condition, accept}) => {
+			if (!condition()) return true;
+			else accept();
+		})
+		
+		for (let i = 0; i < this.#pendingMutations.length; ++i) {
+			if (!this.#pendingMutations[i].condition())
+				continue;
+
+			const {accept} = this.#pendingMutations[i];
+			this.#pendingMutations.splice(i, 1);
+				
+			// If accept() returns true, it means no mutation and we
+			// can check the other conditions as well?
+			accept(); // <- this may recursively call `#checkAfterwards()`!
+			break;
+		}
+
+		return retval;
+	}
+
+	until(condition) {
+		return this.#checkAfterwards(() => new Promise(accept => {
+			this.#pendingConditions.push({condition, accept});
+		}));
+	}
+
+	untilEmpty() {
+		return this.until(() => this.length === 0);
+	}
+
+	shiftAsync() {
+		return this.#checkAfterwards(() => new Promise(accept => {
+			this.#pendingMutations.push({
+				condition: () => this.length > 0,
+				accept: () => accept(this.shift())
+			})
+		}));
+	}
+}
+
+function msleep(duration) {
+	return new Promise((accept) => {
+		setTimeout(accept, duration);
+	});
+}
+
 let counter = 0;
 
 function increment(element) {
@@ -38,13 +115,18 @@ document.querySelectorAll('[data-callback]').forEach(element => {
 });
 
 document.querySelectorAll('#controls').forEach(section => {
-	let queue = [];
+	const queue = new Queue();
+
+	// Fake observer to call render every time the queue changes hehehe
+	queue.until(() => {
+		requestIdleCallback(render);
+		return false;
+	});
 
 	const ipt = new InPageTranslation({
 		translate(text, user) {
 			queue.push({text, user});
 			if (queue.length > 50) throw new Error('Runaway!');
-			requestIdleCallback(render);
 		}
 	});
 
@@ -73,20 +155,18 @@ document.querySelectorAll('#controls').forEach(section => {
 	section.querySelector('#translate-head').addEventListener('click', e => {
 		const request = queue.shift();
 		ipt.enqueueTranslationResponse(translate(request.text), request.user);
-		render();
 	});
 
 	section.querySelector('#translate-tail').addEventListener('click', e => {
 		const request = queue.pop();
 		ipt.enqueueTranslationResponse(translate(request.text), request.user);
-		render();
 	});
 
 	section.querySelector('#toggle').addEventListener('click', e => {
 		if (ipt.started) {
 			ipt.stop();
 			console.log(ipt.processedNodes);
-			queue = [];
+			queue.reset();
 		}
 		
 		ipt.start('en');
@@ -96,8 +176,70 @@ document.querySelectorAll('#controls').forEach(section => {
 
 	section.querySelector('#restore').addEventListener('click', e => {
 		ipt.restore();
-		queue = []; // because restore() involves stop()
-		render();
+		queue.reset(); // because restore() involves stop()
+	})
+
+	section.querySelector('#run').addEventListener('click', async (e) => {
+		class StopCondition {
+			constructor(accept) {
+				this.name = 'StopError';
+				this.accept = accept;
+			}
+		}
+
+		var stop;
+
+		let condition = new Promise((acceptStop) => {
+			stop = () => new Promise((acceptStopped) => {
+				acceptStop(new StopCondition(acceptStopped));
+			});
+		});
+
+		const worker = async () => {
+			while (true) {
+				const request = await Promise.race([condition, queue.shiftAsync()]);
+				
+				if (request instanceof StopCondition) {
+					request.accept();
+					break;
+				}
+				
+				ipt.enqueueTranslationResponse(translate(request.text), request.user);
+			}
+			console.log('stop condition met');
+		};
+
+		e.target.disabled = true;
+
+		worker(); // Start translating async
+
+		ipt.start('en');
+
+		await queue.untilEmpty();
+
+		for (let i = 5; i > 0; --i) {
+			addParagraph(document.querySelector('#dynamic'));
+			increment(document.querySelector('#counter'));
+			await msleep(500);
+		}
+
+		// Wait till mutation is picked up
+		await queue.until(() => queue.length > 0);
+
+		// Then wait till all mutations are processed again
+		await queue.until(() => queue.length === 0);
+
+		// Problem: queue empty does not mean that the translations have been
+		// processed by InPageTranslation!
+
+		// Restore page
+		await msleep(1500);
+		ipt.restore();
+
+		// Stop worker (and wait till it has confirmed it stopped)
+		await stop();
+
+		e.target.disabled = false;
 	})
 
 	render();

--- a/extension/view/static/test.js
+++ b/extension/view/static/test.js
@@ -94,5 +94,11 @@ document.querySelectorAll('#controls').forEach(section => {
 		render();
 	});
 
+	section.querySelector('#restore').addEventListener('click', e => {
+		ipt.restore();
+		queue = []; // because restore() involves stop()
+		render();
+	})
+
 	render();
 })


### PR DESCRIPTION
General steps of the process:
- Record nodes that we will be translating:
  - Record child position of children of element nodes
  - Record text content of text nodes
  - (I think those are the only two things we have an impact on from InPageTranslation)
- Record any mutations that are caused by the page (not by translation!) and keep our record up-to-date
- Restore page using our records to re-arrange DOM nodes